### PR TITLE
 Fix syntax errors in transporter docs code examples

### DIFF
--- a/source/0.11/docs/transporters.md
+++ b/source/0.11/docs/transporters.md
@@ -74,6 +74,7 @@ let broker = new ServiceBroker({
                 pass: "1234"
             }
         }
+    }
 });
 
 // Shorthand with TLS
@@ -92,6 +93,7 @@ let broker = new ServiceBroker({
                 }
             }
         }
+    }
 });
 ```
 
@@ -164,6 +166,7 @@ let broker = new ServiceBroker({
                 db: 0
             }
         }
+    }
 });
 ```
 
@@ -235,6 +238,7 @@ let broker = new ServiceBroker({
                 port: 1883,
             }
         }
+    }
 });
 ```
 
@@ -305,6 +309,7 @@ let broker = new ServiceBroker({
                 port: 5672,
             }
         }
+    }
 });
 ```
 

--- a/source/0.12/docs/transporters.md
+++ b/source/0.12/docs/transporters.md
@@ -156,6 +156,7 @@ const broker = new ServiceBroker({
             user: "admin",
             pass: "1234"
         }
+    }
 });
 
 // Connect with TLS
@@ -171,6 +172,7 @@ const broker = new ServiceBroker({
                 ca: [ fs.readFileSync('./ca.pem') ]
             }
         }
+    }
 });
 ```
 
@@ -209,6 +211,7 @@ const broker = new ServiceBroker({
             host: "redis-server",
             db: 0
         }
+    }
 });
 ```
 
@@ -247,6 +250,7 @@ const broker = new ServiceBroker({
             host: "mqtt-server",
             port: 1883,
         }
+    }
 });
 ```
 
@@ -288,6 +292,7 @@ const broker = new ServiceBroker({
             eventTimeToLive: 5000,
             prefetch: 1
         }
+    }
 });
 ```
 
@@ -380,6 +385,7 @@ const broker = new ServiceBroker({
             url: "stan://127.0.0.1:4222",
             clusterID: "my-cluster"
         }
+    }
 });
 ```
 


### PR DESCRIPTION
Added a few missing closing brackets to the examples.