### PR TITLE
entityValidator added in example

### DIFF
--- a/source/docs/0.13/moleculer-db.md
+++ b/source/docs/0.13/moleculer-db.md
@@ -49,7 +49,10 @@ broker.createService({
     mixins: [DbService],
 
     settings: {
-        fields: ["_id", "username", "name"]
+        fields: ["_id", "username", "name"],
+        entityValidator: {
+			username: "string"
+		}
     },
 
     afterConnected() {


### PR DESCRIPTION
entityValidator is added in the first example to let users know how to add field validation in create/insert calls