### PR TITLE
Correct mcall parameters example

### DIFF
--- a/source/docs/0.13/api/service-broker.md
+++ b/source/docs/0.13/api/service-broker.md
@@ -558,7 +558,7 @@ Call `mcall` with an array:
 ```js
 broker.mcall([
 	{ action: "posts.find", params: { limit: 5, offset: 0 } },
-	{ action: "users.find", params: { limit: 5, sort: "username" }, opts: { timeout: 500 } }
+	{ action: "users.find", params: { limit: 5, sort: "username" }, options: { timeout: 500 } }
 ]).then(results => {
 	let posts = results[0];
 	let users = results[1];
@@ -573,7 +573,7 @@ Call `mcall` with an Object:
 ```js
 broker.mcall({
 	posts: { action: "posts.find", params: { limit: 5, offset: 0 } },
-	users: { action: "users.find", params: { limit: 5, sort: "username" }, opts: { timeout: 500 } }
+	users: { action: "users.find", params: { limit: 5, sort: "username" }, options: { timeout: 500 } }
 }).then(results => {
 	let posts = results.posts;
 	let users = results.users;

--- a/source/docs/0.14/api/service-broker.md
+++ b/source/docs/0.14/api/service-broker.md
@@ -498,7 +498,7 @@ Call `mcall` with an array:
 ```js
 broker.mcall([
 	{ action: "posts.find", params: { limit: 5, offset: 0 } },
-	{ action: "users.find", params: { limit: 5, sort: "username" }, opts: { timeout: 500 } }
+	{ action: "users.find", params: { limit: 5, sort: "username" }, options: { timeout: 500 } }
 ]).then(results => {
 	let posts = results[0];
 	let users = results[1];
@@ -513,7 +513,7 @@ Call `mcall` with an Object:
 ```js
 broker.mcall({
 	posts: { action: "posts.find", params: { limit: 5, offset: 0 } },
-	users: { action: "users.find", params: { limit: 5, sort: "username" }, opts: { timeout: 500 } }
+	users: { action: "users.find", params: { limit: 5, sort: "username" }, options: { timeout: 500 } }
 }).then(results => {
 	let posts = results.posts;
 	let users = results.users;


### PR DESCRIPTION
mcall using 3 params `action`, `params`, `options` but example said `action`, `params`, `opts`