### PR TITLE
Wrong and misleading custom populator example

### DIFF
--- a/source/docs/0.14/moleculer-db.md
+++ b/source/docs/0.14/moleculer-db.md
@@ -519,7 +519,12 @@ broker.createService({
             },
 
             // Custom populator handler function
-            "rate"(ids, rule, ctx) {
+            "rate"(ids, items, rule, ctx) {
+                // items argument is a mutable array containing response items
+                // the resolved value from promise do not matter - items array will always be passed as populated response
+                // so you should du custom populate by mutating items, if confused check implementaion:
+                // https://github.com/moleculerjs/moleculer-db/blob/master/packages/moleculer-db/src/index.js#L636
+                
                 return Promise.resolve(...);
             }
         }


### PR DESCRIPTION
Improved by documenting the right arguments and noticing that
resolved value from promise do not matter only mutating items is
the way to change the response!

I've found it by digging in implementation here - https://github.com/moleculerjs/moleculer-db/blob/master/packages/moleculer-db/src/index.js#L636

This error could be in previous version of docs too!