### PR TITLE
update helper so headings w/o id's are not linked

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -209,6 +209,7 @@ hexo.extend.helper.register('page_anchor', function(str){
 
 	headings.each(function(){
 		var id = $(this).attr('id');
+        if (!id) return str;
 
 		$(this)
 			.addClass('article-heading')


### PR DESCRIPTION
closes #98 

- adds a return so headings without ids are not linked.