### PR TITLE
WIP: Update multipart form-data alias documentation

### DIFF
--- a/source/docs/0.14/moleculer-web.md
+++ b/source/docs/0.14/moleculer-web.md
@@ -269,6 +269,12 @@ module.exports = {
     }
 });
 ```
+**Multipart files**
+
+In order to access the files passed by multipart-form these specific fields can be used inside the action:
+- `ctx.params` is the Readable stream containing the file passed to the endpoint
+- `ctx.meta.$multipart` contains the additional text form-data fields passed _before other files fields_.
+
 ### Auto-alias
 The auto-alias feature allows you to declare your route alias directly in your services. The gateway will dynamically build the full routes from service schema.
 

--- a/source/docs/0.14/moleculer-web.md
+++ b/source/docs/0.14/moleculer-web.md
@@ -212,7 +212,7 @@ broker.createService({
 You can't request the `/math.add` or `/math/add` URLs, only `POST /add`.
 
 ### File upload aliases
-API Gateway has implemented file uploads. You can upload files as a ù form data (thanks to [busboy](https://github.com/mscdex/busboy) library) or as a raw request body. In both cases, the file is transferred to an action as a `Stream`. In multipart form data mode you can upload multiple files, as well.
+API Gateway has implemented file uploads. You can upload files as a multipart form data (thanks to [busboy](https://github.com/mscdex/busboy) library) or as a raw request body. In both cases, the file is transferred to an action as a `Stream`. In multipart form data mode you can upload multiple files, as well.
 
 {% note warn %}
 Please note, you have to disable other body parsers in order to accept files.

--- a/source/docs/0.14/moleculer-web.md
+++ b/source/docs/0.14/moleculer-web.md
@@ -212,7 +212,7 @@ broker.createService({
 You can't request the `/math.add` or `/math/add` URLs, only `POST /add`.
 
 ### File upload aliases
-API Gateway has implemented file uploads. You can upload files as a multipart form data (thanks to [busboy](https://github.com/mscdex/busboy) library) or as a raw request body. In both cases, the file is transferred to an action as a `Stream`. In multipart form data mode you can upload multiple files, as well.
+API Gateway has implemented file uploads. You can upload files as a ù form data (thanks to [busboy](https://github.com/mscdex/busboy) library) or as a raw request body. In both cases, the file is transferred to an action as a `Stream`. In multipart form data mode you can upload multiple files, as well.
 
 {% note warn %}
 Please note, you have to disable other body parsers in order to accept files.
@@ -269,7 +269,7 @@ module.exports = {
     }
 });
 ```
-**Multipart files**
+**Multipart parameters**
 
 In order to access the files passed by multipart-form these specific fields can be used inside the action:
 - `ctx.params` is the Readable stream containing the file passed to the endpoint


### PR DESCRIPTION
I think the documentation abount multipart formdata lacks a lot of information. With this MR I wanted to solve this.

I've updated multipart form-data alias documentation for endpoint with file upload by busboy...
This is still a WIP because there should be the documentation for multiple files formData as well.

Changes and commits are welcomed.

This MR is related also to these issues: https://github.com/moleculerjs/moleculer-web/issues/140, https://github.com/moleculerjs/moleculer-web/issues/154