### PR TITLE
Update Dockerfile example to enable graceful shutdown

### DIFF
--- a/source/docs/0.14/deploying.md
+++ b/source/docs/0.14/deploying.md
@@ -27,7 +27,8 @@ RUN npm install --production
 
 COPY . .
 
-CMD ["npm", "start"]  # Execute moleculer-runner
+# Execute moleculer-runner
+CMD ["node", "./node_modules/moleculer/bin/moleculer-runner.js"]
 ```
 
 ### Docker Compose


### PR DESCRIPTION
This PR updates the Dockerfile example in the 0.14 docs to use node directly to start the moleculer runner instead of relying on an npm script. Npm does not forward signals to child-processes so if the npm process receives a `SIGINT` or `SIGTERM`, the npm process will simply die without passing the signal to moleculer. This means that moleculer will not initiate a graceful shutdown. This also applies to the bash scripts in the `node_modules\.bin` directory, which is why the change uses the relative path to the moleculer-runner.js file. 

[node best practices](https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/docker/bootstrap-using-node.md)
[npm issue #4603](https://github.com/npm/npm/issues/4603)