### PR TITLE
Fix moleculerjs/moleculer-web#242

### DIFF
--- a/source/docs/0.14/moleculer-web.md
+++ b/source/docs/0.14/moleculer-web.md
@@ -297,7 +297,7 @@ module.exports = {
                 path: "/api",
 
                 whitelist: [
-                    "posts.*",
+                    "v2.posts.*",
                     "test.*"
                 ],
 
@@ -320,7 +320,9 @@ module.exports = {
 
     settings: {
         // Base path
-        rest: "posts/"
+        // rest: "posts/" // If you want to change the base 
+        // path with /api/posts instead 
+        // of /api/v2/posts, you can uncomment this line.
     },
 
     actions: {


### PR DESCRIPTION
Added version prefix before the service name in whitelist.
Commented the rest setting because it conflicts with the other comments: When you use base path it doesn't automatically add version prefix on path. (/api/posts instead /api/v2/posts)