### PR TITLE
Use npx to create new project in installation docs

### DIFF
--- a/source/docs/0.12/usage.md
+++ b/source/docs/0.12/usage.md
@@ -44,26 +44,22 @@ Open this example on [Runkit!](https://runkit.com/icebob/moleculer-usage)
 # Create a Moleculer project
 Use the [Moleculer CLI tool](moleculer-cli.html) to create a new Moleculer-based microservices project.
 
-1. Install `moleculer-cli` globally
+1. Create a new project (named `first-demo`)
     ```bash
-    $ npm install moleculer-cli -g
-    ```
-2. Create a new project (named `first-demo`)
-    ```bash
-    $ moleculer init project moleculer-demo
+    $ npx -p moleculer-cli moleculer init project moleculer-demo
     ```
     > Press Y to all questions
     
-3. Open project folder
+2. Open project folder
     ```bash
     $ cd moleculer-demo
     ```
     
-4. Start project
+3. Start project
     ```bash
     $ npm run dev
     ```
-5. Open the [http://localhost:3000/](http://localhost:3000/) link in your browser. It shows a start page which contains two links to call the `greeter` service via [API gateway](https://github.com/moleculerjs/moleculer-web).
+4. Open the [http://localhost:3000/](http://localhost:3000/) link in your browser. It shows a start page which contains two links to call the `greeter` service via [API gateway](https://github.com/moleculerjs/moleculer-web).
 
 {% note info Congratulations! %}
 You have just created your first Moleculer-based microservices project! The next step is to check our [examples](examples.html) or [demo projects](https://github.com/moleculerjs/moleculer-examples).

--- a/source/docs/0.13/usage.md
+++ b/source/docs/0.13/usage.md
@@ -40,13 +40,9 @@ Open this example on [Runkit!](https://runkit.com/icebob/moleculer-usage)
 # Create a Moleculer project
 Use the [Moleculer CLI tool](moleculer-cli.html) to create a new Moleculer-based microservices project.
 
-1. Install `moleculer-cli` globally
+1. Create a new project (named `moleculer-demo`)
     ```bash
-    $ npm i moleculer-cli -g
-    ```
-2. Create a new project (named `moleculer-demo`)
-    ```bash
-    $ moleculer init project moleculer-demo
+    $ npx -p moleculer-cli moleculer init project moleculer-demo
     ```
     > Press `Y` to all questions
     
@@ -54,16 +50,16 @@ Use the [Moleculer CLI tool](moleculer-cli.html) to create a new Moleculer-based
     > `NATS error. Could not connect to server: Error: connect ECONNREFUSED 127.0.0.1:4222`
 
 
-3. Open project folder
+2. Open project folder
     ```bash
     $ cd moleculer-demo
     ```
 
-4. Start project
+3. Start project
     ```bash
     $ npm run dev
     ```
-5. Open the [http://localhost:3000/](http://localhost:3000/) link in your browser. It shows a start page which contains two links to call the `greeter` service via [API gateway](https://github.com/moleculerjs/moleculer-web).
+4. Open the [http://localhost:3000/](http://localhost:3000/) link in your browser. It shows a start page which contains two links to call the `greeter` service via [API gateway](https://github.com/moleculerjs/moleculer-web).
 
 {% note info Congratulations! %}
 You have just created your first Moleculer-based microservices project! Next, check out Moleculer's [core concepts](concepts.html) page to get familiar with them and to see how they fit together. Otherwise, check our [examples](examples.html) or [demo projects](https://github.com/moleculerjs/moleculer-examples).

--- a/source/docs/0.14/usage.md
+++ b/source/docs/0.14/usage.md
@@ -43,13 +43,9 @@ Open this example on [Runkit!](https://runkit.com/icebob/moleculer-usage)
 # Create a Moleculer project
 In this example we use the official [Moleculer CLI tool](moleculer-cli.html) to create a new Moleculer-based microservices project with a sample service and an API Gateway to call it from the browser via REST API.
 
-1. Install `moleculer-cli` globally
+1. Create a new project (named `moleculer-demo`)
     ```bash
-    $ npm i moleculer-cli -g
-    ```
-2. Create a new project (named `moleculer-demo`)
-    ```bash
-    $ moleculer init project moleculer-demo
+    $ npx -p moleculer-cli moleculer init project moleculer-demo
     ```
     <div align="center"><img src="assets/usage/usage-demo-1.gif" /></div>    
 
@@ -60,19 +56,19 @@ In this example we use the official [Moleculer CLI tool](moleculer-cli.html) to 
     `NATS error. Could not connect to server: Error: connect ECONNREFUSED 127.0.0.1:4222`
     {% endnote %}
 
-3. Open project folder
+2. Open project folder
     ```bash
     $ cd moleculer-demo
     ```
 
-4. Start project
+3. Start project
     ```bash
     $ npm run dev
     ```
 
     <div align="center"><img src="assets/usage/usage-demo-2.gif" /></div>
 
-5. Open the [http://localhost:3000/](http://localhost:3000/) link in your browser. It shows a start page which contains two links to call the `greeter` service via [API gateway](https://github.com/moleculerjs/moleculer-web).
+4. Open the [http://localhost:3000/](http://localhost:3000/) link in your browser. It shows a start page which contains two links to call the `greeter` service via [API gateway](https://github.com/moleculerjs/moleculer-web).
 
 {% note info Congratulations! %}
 You have just created your first Moleculer-based microservices project! Next, check out Moleculer's [core concepts](concepts.html) page to get familiar with them and to see how they fit together. Otherwise, check our [examples](examples.html) or [demo projects](https://github.com/moleculerjs/moleculer-examples).


### PR DESCRIPTION
This saves the user from installing a global package, in favor of using `npx`.