### PR TITLE
Update fault-tolerance.md

### DIFF
--- a/source/docs/0.14/fault-tolerance.md
+++ b/source/docs/0.14/fault-tolerance.md
@@ -134,7 +134,7 @@ broker.call("posts.find", {}, { timeout: 3000 });
 ```
 
 ### Distributed timeouts
-Moleculer uses [distributed timeouts](https://www.datawire.io/guide/traffic/deadlines-distributed-timeouts-microservices/). In case of nested calls, the timeout value is decremented with the elapsed time. If the timeout value is less or equal than 0, the next nested calls will be skipped (`RequestSkippedError`) because the first call has already been rejected with a `RequestTimeoutError` error.
+Moleculer uses [distributed timeouts](https://www.getambassador.io/learn/service-mesh/resilience-for-distributed-systems/#:~:text=too%20many%20times.-,Deadlines,-In%20addition%20to). In case of nested calls, the timeout value is decremented with the elapsed time. If the timeout value is less or equal than 0, the next nested calls will be skipped (`RequestSkippedError`) because the first call has already been rejected with a `RequestTimeoutError` error.
 
 ## Bulkhead
 Bulkhead feature is implemented in Moleculer framework to control the concurrent request handling of actions.


### PR DESCRIPTION
The original hyperlink changed.

Maybe now is: https://www.getambassador.io/learn/service-mesh/resilience-for-distributed-systems/#:~:text=too%20many%20times.-,Deadlines,-In%20addition%20to

\nother reference:
https://itnext.io/5-patterns-to-make-your-microservice-fault-tolerant-f3a1c73547b3