### PR TITLE
Fix typo in comment

### DIFF
--- a/source/docs/0.14/moleculer-web.md
+++ b/source/docs/0.14/moleculer-web.md
@@ -560,7 +560,7 @@ broker.createService({
             // Root folder of assets
             folder: "./assets",
 
-            // Further options to `server-static` module
+            // Further options to `serve-static` module
             options: {}
         }		
     }


### PR DESCRIPTION
Its looks like all comment in moleculerjs template about those is all wrong. (I just wanna fix origin one)

`server-static` is another package. and in source code, using `serve-static` (from express)

Reference:
- server-static: https://www.npmjs.com/package/server-static
- serve-static: https://www.npmjs.com/package/serve-static